### PR TITLE
Generating virtual staining model inference

### DIFF
--- a/4.virtual_staining_analysis/4.1a.run_model_inferences_unet.py
+++ b/4.virtual_staining_analysis/4.1a.run_model_inferences_unet.py
@@ -11,7 +11,7 @@
 # 3. For each model run, load weights → iterate over (plate, row) groups → crop single-cell patches → run inference → write per-cell TIFF outputs and update the checkpoint index.
 # 4. Tear down the checkpoint session, cleaning up any empty run directories.
 
-# In[1]:
+# In[ ]:
 
 
 import pathlib
@@ -32,27 +32,26 @@ from vs_eval_utils.inference_checkpointing import ( # type: ignore
 )
 from vs_eval_utils.model_loader import load_model_weights
 from vs_eval_utils.model_inference import inference_and_checkpoint
+from vs_eval_utils.ds_utils import prep_crop_dataset
 from vs_eval_utils.nb_utils import find_git_root
 
 
-# In[2]:
+# In[ ]:
 
 
 # virtual staining model and dataset
 from virtual_stain_flow.models.unet import UNet
-from virtual_stain_flow.datasets.cp_loaddata_dataset import CPLoadDataImageDataset
 from virtual_stain_flow.datasets.crop_cell_dataset import CropCellImageDataset
-from virtual_stain_flow.transforms.normalizations import MaxScaleNormalize
 
 
-# In[3]:
+# In[ ]:
 
 
 INFERENCE_DIR = pathlib.Path('/mnt/hdd20tb/vsf_inference')
 INFERENCE_DIR.mkdir(exist_ok=True) 
 
 
-# In[4]:
+# In[ ]:
 
 
 ANALYSIS_REPO_ROOT = find_git_root()
@@ -72,7 +71,7 @@ if not SC_FEATURES_DIR.exists():
     raise FileNotFoundError(f"Single-cell features directory not found at {SC_FEATURES_DIR}")
 
 
-# In[5]:
+# In[ ]:
 
 
 PLATES: list[str] | None = ["BR00143976", "BR00143977"]
@@ -127,8 +126,21 @@ loaddata_df_sub = loaddata_df_sub.loc[
 ]
 print (f"Subset loaddata_df_sub to {len(loaddata_df_sub)} rows based on intersection with sc_features.")
 
+def prep_crop_ds_wrap(loaddata_df: pd.DataFrame) -> CropCellImageDataset:
+    """
+    Wrapped helper to specify the sc_features argument for dataset preparation
+    """
+    try:
+        return prep_crop_dataset(
+            loaddata_df,
+            sc_features # good for all batch 1
+        )
+    except Exception as e:
+        print(f"Error preparing dataset: {e}")
+        raise e
 
-# In[6]:
+
+# In[ ]:
 
 
 devices = {}
@@ -145,7 +157,7 @@ else:
 DEVICE = devices['NVIDIA RTX A6000']
 
 
-# In[7]:
+# In[ ]:
 
 
 checked_run_path = pathlib.Path(
@@ -160,7 +172,7 @@ print(f"Total UNet runs: {len(unet_run_info_df)}")
 unet_run_info_df.head()
 
 
-# In[8]:
+# In[ ]:
 
 
 set_checkpoint_index(
@@ -170,55 +182,14 @@ set_checkpoint_index(
 )
 
 
-# In[9]:
+# In[ ]:
 
 
 df = get_checkpoint_index()
 df.head()
 
 
-# In[10]:
-
-
-def prep_crop_dataset(
-    loaddata_df: pd.DataFrame,
-    sc_features: pd.DataFrame = sc_features, # good for all batch 1
-) -> CropCellImageDataset:
-    """
-    Helper invoking the virtual_stain_flow dataset initialization steps
-        to prepare a CropCellImageDataset from a loaddata DataFrame.
-
-    :param loaddata_df: DataFrame containing the loaddata information for 
-        the samples to be included in the dataset
-    :param sc_features: DataFrame containing the single-cell features 
-        for the samples. The notebook initializes a global sc_features DataFrame
-        that is used as default argument here. 
-    :return: Initialized CropCellImageDataset ready for inference
-    """
-    cp_ids = CPLoadDataImageDataset(
-            loaddata=loaddata_df,
-            sc_feature=sc_features,
-            pil_image_mode="I;16",
-        )
-    crop_ds = CropCellImageDataset.from_dataset(
-        cp_ids,
-        patch_size=256,
-        object_coord_x_field="Metadata_Cells_Location_Center_X",
-        object_coord_y_field="Metadata_Cells_Location_Center_Y",
-        fov=(1080, 1080),
-    )
-    crop_ds.transform = MaxScaleNormalize(
-        p=1,
-        normalization_factor=2**16 - 1,  # normalize to [0, 1]
-    )
-    crop_ds.input_channel_keys = ["OrigBrightfield"]
-    # Any target channel is fine for eval as we only need input BF
-    crop_ds.target_channel_keys = ["OrigBrightfield"]
-
-    return crop_ds
-
-
-# In[11]:
+# In[ ]:
 
 
 for i, run_row in unet_run_info_df.reset_index(drop=True,inplace=False).iterrows():
@@ -246,12 +217,7 @@ for i, run_row in unet_run_info_df.reset_index(drop=True,inplace=False).iterrows
 
     for conds, group in loaddata_df_sub.groupby(
         ['Metadata_Plate', 'row']
-    ):  
-        # try:  
-        #     dataset = prep_crop_dataset(group)
-        # except Exception as e:
-        #     print(f"Error preparing dataset for conditions {conds}: {e}")
-        #     continue    
+    ): 
 
         try:
             inference_and_checkpoint(
@@ -259,7 +225,7 @@ for i, run_row in unet_run_info_df.reset_index(drop=True,inplace=False).iterrows
                 model_metadata=run_row,
                 tasks=group,
                 dataset=None,
-                dataset_fn=prep_crop_dataset,
+                dataset_fn=prep_crop_ds_wrap,
                 output_root=pathlib.Path(INFERENCE_DIR),
                 output_flat=False,
                 device=DEVICE,
@@ -269,7 +235,7 @@ for i, run_row in unet_run_info_df.reset_index(drop=True,inplace=False).iterrows
             continue        
 
 
-# In[12]:
+# In[ ]:
 
 
 teardown_checkpoint_index()

--- a/4.virtual_staining_analysis/4.1a.run_model_inferences_unet.py
+++ b/4.virtual_staining_analysis/4.1a.run_model_inferences_unet.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-# # 4.1b. Run Model Inferences (wGAN)
+# # 4.1a. Run Model Inferences (UNet)
 # 
-# This notebook runs batch inference for trained virtual staining models (wGAN architecture) on the evaluation split of the pediatric cancer atlas imaging data.
+# This notebook runs batch inference for trained virtual staining models (UNet architecture) on the evaluation split of the pediatric cancer atlas imaging data.
 # 
 # **Workflow:**
 # 1. Load the evaluation loaddata and single-cell feature tables, filtering to plates of interest.
@@ -11,7 +11,7 @@
 # 3. For each model run, load weights → iterate over (plate, row) groups → crop single-cell patches → run inference → write per-cell TIFF outputs and update the checkpoint index.
 # 4. Tear down the checkpoint session, cleaning up any empty run directories.
 
-# In[ ]:
+# In[1]:
 
 
 import pathlib
@@ -35,7 +35,7 @@ from vs_eval_utils.model_inference import inference_and_checkpoint
 from vs_eval_utils.nb_utils import find_git_root
 
 
-# In[ ]:
+# In[2]:
 
 
 # virtual staining model and dataset
@@ -45,14 +45,14 @@ from virtual_stain_flow.datasets.crop_cell_dataset import CropCellImageDataset
 from virtual_stain_flow.transforms.normalizations import MaxScaleNormalize
 
 
-# In[ ]:
+# In[3]:
 
 
 INFERENCE_DIR = pathlib.Path('/mnt/hdd20tb/vsf_inference')
 INFERENCE_DIR.mkdir(exist_ok=True) 
 
 
-# In[ ]:
+# In[4]:
 
 
 ANALYSIS_REPO_ROOT = find_git_root()
@@ -72,7 +72,7 @@ if not SC_FEATURES_DIR.exists():
     raise FileNotFoundError(f"Single-cell features directory not found at {SC_FEATURES_DIR}")
 
 
-# In[ ]:
+# In[5]:
 
 
 PLATES: list[str] | None = ["BR00143976", "BR00143977"]
@@ -128,7 +128,7 @@ loaddata_df_sub = loaddata_df_sub.loc[
 print (f"Subset loaddata_df_sub to {len(loaddata_df_sub)} rows based on intersection with sc_features.")
 
 
-# In[ ]:
+# In[6]:
 
 
 devices = {}
@@ -145,22 +145,22 @@ else:
 DEVICE = devices['NVIDIA RTX A6000']
 
 
-# In[ ]:
+# In[7]:
 
 
 checked_run_path = pathlib.Path(
-    '/mnt/hdd20tb/alpine_eval/checked_model_runs.csv'
+    'checked_model_runs.csv'
 )
 if not checked_run_path.exists():
     raise RuntimeError(f'Checked run info file not found at {checked_run_path}')
 
 all_run_info_df = pd.read_csv(checked_run_path)
-wgan_run_info_df = all_run_info_df[all_run_info_df['architecture'] == 'wGAN']
-print(f"Total wGAN runs: {len(wgan_run_info_df)}")
-wgan_run_info_df.head()
+unet_run_info_df = all_run_info_df[all_run_info_df['architecture'] == 'UNet']
+print(f"Total UNet runs: {len(unet_run_info_df)}")
+unet_run_info_df.head()
 
 
-# In[ ]:
+# In[8]:
 
 
 set_checkpoint_index(
@@ -170,14 +170,14 @@ set_checkpoint_index(
 )
 
 
-# In[ ]:
+# In[9]:
 
 
 df = get_checkpoint_index()
 df.head()
 
 
-# In[ ]:
+# In[10]:
 
 
 def prep_crop_dataset(
@@ -218,10 +218,10 @@ def prep_crop_dataset(
     return crop_ds
 
 
-# In[ ]:
+# In[11]:
 
 
-for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows():
+for i, run_row in unet_run_info_df.reset_index(drop=True,inplace=False).iterrows():
 
     run_id = run_row['run_id']
     run_path = pathlib.Path(run_row["path"])
@@ -231,7 +231,13 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
             run_path,
             device=DEVICE,
             model_handle=UNet,
-            model_config=None,
+            model_config={
+                "init": {
+                    "in_channels": 1,
+                    "out_channels": 1,
+                    "depth": 4,
+                }
+            },
             compile_model=False
         )
     except Exception:
@@ -241,18 +247,19 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
     for conds, group in loaddata_df_sub.groupby(
         ['Metadata_Plate', 'row']
     ):  
-        try:  
-            dataset = prep_crop_dataset(group)
-        except Exception as e:
-            print(f"Error preparing dataset for conditions {conds}: {e}")
-            continue    
+        # try:  
+        #     dataset = prep_crop_dataset(group)
+        # except Exception as e:
+        #     print(f"Error preparing dataset for conditions {conds}: {e}")
+        #     continue    
 
         try:
             inference_and_checkpoint(
                 model=model,
                 model_metadata=run_row,
                 tasks=group,
-                dataset=dataset,
+                dataset=None,
+                dataset_fn=prep_crop_dataset,
                 output_root=pathlib.Path(INFERENCE_DIR),
                 output_flat=False,
                 device=DEVICE,
@@ -262,7 +269,7 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
             continue        
 
 
-# In[ ]:
+# In[12]:
 
 
 teardown_checkpoint_index()

--- a/4.virtual_staining_analysis/4.1b.run_model_inferences_wgan.py
+++ b/4.virtual_staining_analysis/4.1b.run_model_inferences_wgan.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# # 4.1b. Run Model Inferences (wGAN)
+# 
+# This notebook runs batch inference for trained virtual staining models (wGAN architecture) on the evaluation split of the pediatric cancer atlas imaging data.
+# 
+# **Workflow:**
+# 1. Load the evaluation loaddata and single-cell feature tables, filtering to plates of interest.
+# 2. Initialise the checkpoint index so that already-completed inference tasks are skipped on re-runs.
+# 3. For each model run, load weights → iterate over (plate, row) groups → crop single-cell patches → run inference → write per-cell TIFF outputs and update the checkpoint index.
+# 4. Tear down the checkpoint session, cleaning up any empty run directories.
+
+# In[ ]:
+
+
+import pathlib
+import sys
+
+import pandas as pd
+import torch
+
+# utils
+# temporary path hack before the package dependencies is determined and solved
+utils_path = pathlib.Path('.') / 'src'
+sys.path.append(str(utils_path))
+from vs_eval_utils.inference_checkpointing import ( # type: ignore
+    set_checkpoint_index,
+    get_checkpoint_index,
+    teardown_checkpoint_index,
+)
+from vs_eval_utils.model_loader import load_model_weights
+from vs_eval_utils.model_inference import inference_and_checkpoint
+
+
+# In[ ]:
+
+
+# virtual staining model and dataset
+from virtual_stain_flow.models.unet import UNet
+from virtual_stain_flow.datasets.cp_loaddata_dataset import CPLoadDataImageDataset
+from virtual_stain_flow.datasets.crop_cell_dataset import CropCellImageDataset
+from virtual_stain_flow.transforms.normalizations import MaxScaleNormalize
+
+
+# In[ ]:
+
+
+INFERENCE_DIR = pathlib.Path('/mnt/hdd20tb/vsf_inference')
+INFERENCE_DIR.mkdir(exist_ok=True) 
+
+
+# In[ ]:
+
+
+ANALYSIS_REPO_ROOT = pathlib.Path(
+    '/home/weishanli/Waylab'
+    ) / 'pediatric_cancer_atlas_analysis'
+CONFIG_PATH = ANALYSIS_REPO_ROOT / 'config.yml'
+config = yaml.safe_load(CONFIG_PATH.read_text())
+
+LOADDATA_FILE_PATH = ANALYSIS_REPO_ROOT / '0.data_preprocessing' / 'data_split_loaddata' / 'loaddata_eval.csv'
+assert LOADDATA_FILE_PATH.exists(), f"File not found: {LOADDATA_FILE_PATH}" 
+
+SC_FEATURES_DIR = pathlib.Path(config['paths']['sc_features_path'])
+assert SC_FEATURES_DIR.exists(), f"Directory not found: {SC_FEATURES_DIR}"
+
+
+# In[ ]:
+
+
+PLATES: list[str] | None = ["BR00143976", "BR00143977"]
+
+loaddata_df = pd.read_csv(LOADDATA_FILE_PATH)
+sc_feature_files = list(
+        SC_FEATURES_DIR.glob('*_sc_normalized.parquet')
+    )
+
+sc_features = pd.DataFrame()
+for plate in loaddata_df['Metadata_Plate'].unique():
+    sc_features_parquet = SC_FEATURES_DIR / f'{plate}_sc_normalized.parquet'
+    if not sc_features_parquet.exists():
+        print(f'{sc_features_parquet} does not exist, skipping...')
+        continue 
+    else:
+        sc_features = pd.concat([
+            sc_features, 
+            pd.read_parquet(
+                sc_features_parquet,
+                columns=['Metadata_Plate', 'Metadata_Well', 'Metadata_Site', 'Metadata_Cells_Location_Center_X', 'Metadata_Cells_Location_Center_Y']
+            )
+        ])
+
+sc_multid = pd.MultiIndex.from_frame(
+    sc_features[[
+        'Metadata_Plate',
+        'Metadata_Well',
+        'Metadata_Site',
+    ]]
+)
+
+if PLATES is not None:
+    loaddata_df_sub = loaddata_df[
+        loaddata_df['Metadata_Plate'].isin(PLATES)
+    ].reset_index(drop=True)
+else:
+    loaddata_df_sub = loaddata_df
+
+print(f"Subset loaddata_df to {len(loaddata_df_sub)} rows based on PLATES filter.")
+
+loaddata_multiid = pd.MultiIndex.from_frame(
+    loaddata_df_sub[[
+        'Metadata_Plate',
+        'Metadata_Well',
+        'Metadata_Site',
+    ]]
+)
+
+loaddata_df_sub = loaddata_df_sub.loc[
+    loaddata_multiid.isin(sc_multid),:
+]
+print (f"Subset loaddata_df_sub to {len(loaddata_df_sub)} rows based on intersection with sc_features.")
+
+
+# In[ ]:
+
+
+devices = {}
+
+# List all CUDA devices
+if torch.cuda.is_available():
+    for i in range(torch.cuda.device_count()):
+        name = torch.cuda.get_device_name(i)
+        print(f"Device {i}: {torch.cuda.get_device_name(i)}")
+        devices[name] = torch.device(f'cuda:{i}')
+else:
+    print("No CUDA devices available")
+
+DEVICE = devices['NVIDIA RTX A6000']
+
+
+# In[ ]:
+
+
+checked_run_path = pathlib.Path(
+    '/mnt/hdd20tb/alpine_eval/checked_model_runs.csv'
+)
+if not checked_run_path.exists():
+    raise RuntimeError(f'Checked run info file not found at {checked_run_path}')
+
+all_run_info_df = pd.read_csv(checked_run_path)
+wgan_run_info_df = all_run_info_df[all_run_info_df['architecture'] == 'wGAN']
+print(f"Total wGAN runs: {len(wgan_run_info_df)}")
+wgan_run_info_df.head()
+
+
+# In[ ]:
+
+
+set_checkpoint_index(
+    checkpoint_root=pathlib.Path(
+        INFERENCE_DIR
+    )
+)
+
+
+# In[ ]:
+
+
+df = get_checkpoint_index()
+df.head()
+
+
+# In[ ]:
+
+
+def prep_crop_dataset(
+    loaddata_df: pd.DataFrame,
+    sc_features: pd.DataFrame = sc_features, # good for all batch 1
+) -> CropCellImageDataset:
+    """
+    Helper invoking the virtual_stain_flow dataset initialization steps
+        to prepare a CropCellImageDataset from a loaddata DataFrame.
+
+    :param loaddata_df: DataFrame containing the loaddata information for 
+        the samples to be included in the dataset
+    :param sc_features: DataFrame containing the single-cell features 
+        for the samples. The notebook initializes a global sc_features DataFrame
+        that is used as default argument here. 
+    :return: Initialized CropCellImageDataset ready for inference
+    """
+    cp_ids = CPLoadDataImageDataset(
+            loaddata=loaddata_df,
+            sc_feature=sc_features,
+            pil_image_mode="I;16",
+        )
+    crop_ds = CropCellImageDataset.from_dataset(
+        cp_ids,
+        patch_size=256,
+        object_coord_x_field="Metadata_Cells_Location_Center_X",
+        object_coord_y_field="Metadata_Cells_Location_Center_Y",
+        fov=(1080, 1080),
+    )
+    crop_ds.transform = MaxScaleNormalize(
+        p=1,
+        normalization_factor=2**16 - 1,  # normalize to [0, 1]
+    )
+    crop_ds.input_channel_keys = ["OrigBrightfield"]
+    # Any target channel is fine for eval as we only need input BF
+    crop_ds.target_channel_keys = ["OrigBrightfield"]
+
+    return crop_ds
+
+
+# In[ ]:
+
+
+for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows():
+
+    run_id = run_row['run_id']
+    run_path = pathlib.Path(run_row["path"])
+    print(f"{i}. Processing run_id {run_id} at path {run_path}...")
+    try:
+        model = load_model_weights(
+            run_path,
+            device=DEVICE,
+            model_handle=UNet,
+            model_config=None,
+            compile_model=False
+        )
+    except Exception:
+        model = None
+        print(f"Failed to load model for run_id {run_id} at path {run_path}, skipping...")
+
+    for conds, group in loaddata_df_sub.groupby(
+        ['Metadata_Plate', 'row']
+    ):  
+        try:  
+            dataset = prep_crop_dataset(group)
+        except Exception as e:
+            print(f"Error preparing dataset for conditions {conds}: {e}")
+            continue    
+
+        try:
+            inference_and_checkpoint(
+                model=model,
+                model_metadata=run_row,
+                tasks=group,
+                dataset=dataset,
+                output_root=pathlib.Path(INFERENCE_DIR),
+                output_flat=False,
+                device=DEVICE,
+            )
+        except Exception as e:
+            print(f"Error during inference for conditions {conds}: {e}")
+            continue        
+
+
+# In[ ]:
+
+
+teardown_checkpoint_index()
+

--- a/4.virtual_staining_analysis/4.1b.run_model_inferences_wgan.py
+++ b/4.virtual_staining_analysis/4.1b.run_model_inferences_wgan.py
@@ -32,6 +32,7 @@ from vs_eval_utils.inference_checkpointing import ( # type: ignore
 )
 from vs_eval_utils.model_loader import load_model_weights
 from vs_eval_utils.model_inference import inference_and_checkpoint
+from vs_eval_utils.ds_utils import prep_crop_dataset
 from vs_eval_utils.nb_utils import find_git_root
 
 
@@ -40,9 +41,7 @@ from vs_eval_utils.nb_utils import find_git_root
 
 # virtual staining model and dataset
 from virtual_stain_flow.models.unet import UNet
-from virtual_stain_flow.datasets.cp_loaddata_dataset import CPLoadDataImageDataset
 from virtual_stain_flow.datasets.crop_cell_dataset import CropCellImageDataset
-from virtual_stain_flow.transforms.normalizations import MaxScaleNormalize
 
 
 # In[ ]:
@@ -127,6 +126,19 @@ loaddata_df_sub = loaddata_df_sub.loc[
 ]
 print (f"Subset loaddata_df_sub to {len(loaddata_df_sub)} rows based on intersection with sc_features.")
 
+def prep_crop_ds_wrap(loaddata_df: pd.DataFrame) -> CropCellImageDataset:
+    """
+    Wrapped helper to specify the sc_features argument for dataset preparation
+    """
+    try:
+        return prep_crop_dataset(
+            loaddata_df,
+            sc_features # good for all batch 1
+        )
+    except Exception as e:
+        print(f"Error preparing dataset: {e}")
+        raise e
+
 
 # In[ ]:
 
@@ -180,47 +192,6 @@ df.head()
 # In[ ]:
 
 
-def prep_crop_dataset(
-    loaddata_df: pd.DataFrame,
-    sc_features: pd.DataFrame = sc_features, # good for all batch 1
-) -> CropCellImageDataset:
-    """
-    Helper invoking the virtual_stain_flow dataset initialization steps
-        to prepare a CropCellImageDataset from a loaddata DataFrame.
-
-    :param loaddata_df: DataFrame containing the loaddata information for 
-        the samples to be included in the dataset
-    :param sc_features: DataFrame containing the single-cell features 
-        for the samples. The notebook initializes a global sc_features DataFrame
-        that is used as default argument here. 
-    :return: Initialized CropCellImageDataset ready for inference
-    """
-    cp_ids = CPLoadDataImageDataset(
-            loaddata=loaddata_df,
-            sc_feature=sc_features,
-            pil_image_mode="I;16",
-        )
-    crop_ds = CropCellImageDataset.from_dataset(
-        cp_ids,
-        patch_size=256,
-        object_coord_x_field="Metadata_Cells_Location_Center_X",
-        object_coord_y_field="Metadata_Cells_Location_Center_Y",
-        fov=(1080, 1080),
-    )
-    crop_ds.transform = MaxScaleNormalize(
-        p=1,
-        normalization_factor=2**16 - 1,  # normalize to [0, 1]
-    )
-    crop_ds.input_channel_keys = ["OrigBrightfield"]
-    # Any target channel is fine for eval as we only need input BF
-    crop_ds.target_channel_keys = ["OrigBrightfield"]
-
-    return crop_ds
-
-
-# In[ ]:
-
-
 for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows():
 
     run_id = run_row['run_id']
@@ -231,7 +202,13 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
             run_path,
             device=DEVICE,
             model_handle=UNet,
-            model_config=None,
+            model_config={
+                "init": {
+                    "in_channels": 1,
+                    "out_channels": 1,
+                    "depth": 4,
+                }
+            },
             compile_model=False
         )
     except Exception:
@@ -241,18 +218,14 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
     for conds, group in loaddata_df_sub.groupby(
         ['Metadata_Plate', 'row']
     ):  
-        try:  
-            dataset = prep_crop_dataset(group)
-        except Exception as e:
-            print(f"Error preparing dataset for conditions {conds}: {e}")
-            continue    
 
         try:
             inference_and_checkpoint(
                 model=model,
                 model_metadata=run_row,
                 tasks=group,
-                dataset=dataset,
+                dataset=None,
+                dataset_fn=prep_crop_ds_wrap,
                 output_root=pathlib.Path(INFERENCE_DIR),
                 output_flat=False,
                 device=DEVICE,

--- a/4.virtual_staining_analysis/4.1c.run_model_inferences_unext.py
+++ b/4.virtual_staining_analysis/4.1c.run_model_inferences_unext.py
@@ -11,7 +11,7 @@
 # 3. For each model run, load weights → iterate over (plate, row) groups → crop single-cell patches → run inference → write per-cell TIFF outputs and update the checkpoint index.
 # 4. Tear down the checkpoint session, cleaning up any empty run directories.
 
-# In[1]:
+# In[ ]:
 
 
 import pathlib
@@ -32,27 +32,26 @@ from vs_eval_utils.inference_checkpointing import ( # type: ignore
 )
 from vs_eval_utils.model_loader import load_model_weights
 from vs_eval_utils.model_inference import inference_and_checkpoint
+from vs_eval_utils.ds_utils import prep_crop_dataset
 from vs_eval_utils.nb_utils import find_git_root
 
 
-# In[2]:
+# In[ ]:
 
 
 # virtual staining model and dataset
-from virtual_stain_flow.models.unet import UNet
-from virtual_stain_flow.datasets.cp_loaddata_dataset import CPLoadDataImageDataset
+from virtual_stain_flow.models.unext import ConvNeXtUNet
 from virtual_stain_flow.datasets.crop_cell_dataset import CropCellImageDataset
-from virtual_stain_flow.transforms.normalizations import MaxScaleNormalize
 
 
-# In[3]:
+# In[ ]:
 
 
 INFERENCE_DIR = pathlib.Path('/mnt/hdd20tb/vsf_inference')
 INFERENCE_DIR.mkdir(exist_ok=True) 
 
 
-# In[4]:
+# In[ ]:
 
 
 ANALYSIS_REPO_ROOT = find_git_root()
@@ -72,7 +71,7 @@ if not SC_FEATURES_DIR.exists():
     raise FileNotFoundError(f"Single-cell features directory not found at {SC_FEATURES_DIR}")
 
 
-# In[5]:
+# In[ ]:
 
 
 PLATES: list[str] | None = ["BR00143976", "BR00143977"]
@@ -127,8 +126,21 @@ loaddata_df_sub = loaddata_df_sub.loc[
 ]
 print (f"Subset loaddata_df_sub to {len(loaddata_df_sub)} rows based on intersection with sc_features.")
 
+def prep_crop_ds_wrap(loaddata_df: pd.DataFrame) -> CropCellImageDataset:
+    """
+    Wrapped helper to specify the sc_features argument for dataset preparation
+    """
+    try:
+        return prep_crop_dataset(
+            loaddata_df,
+            sc_features # good for all batch 1
+        )
+    except Exception as e:
+        print(f"Error preparing dataset: {e}")
+        raise e
 
-# In[6]:
+
+# In[ ]:
 
 
 devices = {}
@@ -145,7 +157,7 @@ else:
 DEVICE = devices['NVIDIA RTX A6000']
 
 
-# In[7]:
+# In[ ]:
 
 
 checked_run_path = pathlib.Path(
@@ -160,7 +172,7 @@ print(f"Total ConvNeXtUNet runs: {len(unext_run_info_df)}")
 unext_run_info_df.head()
 
 
-# In[8]:
+# In[ ]:
 
 
 set_checkpoint_index(
@@ -170,61 +182,14 @@ set_checkpoint_index(
 )
 
 
-# In[9]:
+# In[ ]:
 
 
 df = get_checkpoint_index()
 df.head()
 
 
-# In[10]:
-
-
-def prep_crop_dataset(
-    loaddata_df: pd.DataFrame,
-    sc_features: pd.DataFrame = sc_features, # good for all batch 1
-) -> CropCellImageDataset:
-    """
-    Helper invoking the virtual_stain_flow dataset initialization steps
-        to prepare a CropCellImageDataset from a loaddata DataFrame.
-
-    :param loaddata_df: DataFrame containing the loaddata information for 
-        the samples to be included in the dataset
-    :param sc_features: DataFrame containing the single-cell features 
-        for the samples. The notebook initializes a global sc_features DataFrame
-        that is used as default argument here. 
-    :return: Initialized CropCellImageDataset ready for inference
-    """
-    cp_ids = CPLoadDataImageDataset(
-            loaddata=loaddata_df,
-            sc_feature=sc_features,
-            pil_image_mode="I;16",
-        )
-    crop_ds = CropCellImageDataset.from_dataset(
-        cp_ids,
-        patch_size=256,
-        object_coord_x_field="Metadata_Cells_Location_Center_X",
-        object_coord_y_field="Metadata_Cells_Location_Center_Y",
-        fov=(1080, 1080),
-    )
-    crop_ds.transform = MaxScaleNormalize(
-        p=1,
-        normalization_factor=2**16 - 1,  # normalize to [0, 1]
-    )
-    crop_ds.input_channel_keys = ["OrigBrightfield"]
-    # Any target channel is fine for eval as we only need input BF
-    crop_ds.target_channel_keys = ["OrigBrightfield"]
-
-    return crop_ds
-
-
-# In[11]:
-
-
-from virtual_stain_flow.models.unext import ConvNeXtUNet
-
-
-# In[12]:
+# In[ ]:
 
 
 for i, run_row in unext_run_info_df.reset_index(drop=True,inplace=False).iterrows():
@@ -254,7 +219,7 @@ for i, run_row in unext_run_info_df.reset_index(drop=True,inplace=False).iterrow
                 model_metadata=run_row,
                 tasks=group,
                 dataset=None,
-                dataset_fn=prep_crop_dataset,
+                dataset_fn=prep_crop_ds_wrap,
                 output_root=pathlib.Path(INFERENCE_DIR),
                 output_flat=False,
                 device=DEVICE,
@@ -264,7 +229,7 @@ for i, run_row in unext_run_info_df.reset_index(drop=True,inplace=False).iterrow
             continue        
 
 
-# In[13]:
+# In[ ]:
 
 
 teardown_checkpoint_index()

--- a/4.virtual_staining_analysis/4.1c.run_model_inferences_unext.py
+++ b/4.virtual_staining_analysis/4.1c.run_model_inferences_unext.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-# # 4.1b. Run Model Inferences (wGAN)
+# # 4.1a. Run Model Inferences (UNet)
 # 
-# This notebook runs batch inference for trained virtual staining models (wGAN architecture) on the evaluation split of the pediatric cancer atlas imaging data.
+# This notebook runs batch inference for trained virtual staining models (UNet architecture) on the evaluation split of the pediatric cancer atlas imaging data.
 # 
 # **Workflow:**
 # 1. Load the evaluation loaddata and single-cell feature tables, filtering to plates of interest.
@@ -11,7 +11,7 @@
 # 3. For each model run, load weights → iterate over (plate, row) groups → crop single-cell patches → run inference → write per-cell TIFF outputs and update the checkpoint index.
 # 4. Tear down the checkpoint session, cleaning up any empty run directories.
 
-# In[ ]:
+# In[1]:
 
 
 import pathlib
@@ -35,7 +35,7 @@ from vs_eval_utils.model_inference import inference_and_checkpoint
 from vs_eval_utils.nb_utils import find_git_root
 
 
-# In[ ]:
+# In[2]:
 
 
 # virtual staining model and dataset
@@ -45,14 +45,14 @@ from virtual_stain_flow.datasets.crop_cell_dataset import CropCellImageDataset
 from virtual_stain_flow.transforms.normalizations import MaxScaleNormalize
 
 
-# In[ ]:
+# In[3]:
 
 
 INFERENCE_DIR = pathlib.Path('/mnt/hdd20tb/vsf_inference')
 INFERENCE_DIR.mkdir(exist_ok=True) 
 
 
-# In[ ]:
+# In[4]:
 
 
 ANALYSIS_REPO_ROOT = find_git_root()
@@ -72,7 +72,7 @@ if not SC_FEATURES_DIR.exists():
     raise FileNotFoundError(f"Single-cell features directory not found at {SC_FEATURES_DIR}")
 
 
-# In[ ]:
+# In[5]:
 
 
 PLATES: list[str] | None = ["BR00143976", "BR00143977"]
@@ -128,7 +128,7 @@ loaddata_df_sub = loaddata_df_sub.loc[
 print (f"Subset loaddata_df_sub to {len(loaddata_df_sub)} rows based on intersection with sc_features.")
 
 
-# In[ ]:
+# In[6]:
 
 
 devices = {}
@@ -145,22 +145,22 @@ else:
 DEVICE = devices['NVIDIA RTX A6000']
 
 
-# In[ ]:
+# In[7]:
 
 
 checked_run_path = pathlib.Path(
-    '/mnt/hdd20tb/alpine_eval/checked_model_runs.csv'
+    'checked_model_runs.csv'
 )
 if not checked_run_path.exists():
     raise RuntimeError(f'Checked run info file not found at {checked_run_path}')
 
 all_run_info_df = pd.read_csv(checked_run_path)
-wgan_run_info_df = all_run_info_df[all_run_info_df['architecture'] == 'wGAN']
-print(f"Total wGAN runs: {len(wgan_run_info_df)}")
-wgan_run_info_df.head()
+unext_run_info_df = all_run_info_df[all_run_info_df['architecture'] == 'ConvNeXtUNet']
+print(f"Total ConvNeXtUNet runs: {len(unext_run_info_df)}")
+unext_run_info_df.head()
 
 
-# In[ ]:
+# In[8]:
 
 
 set_checkpoint_index(
@@ -170,14 +170,14 @@ set_checkpoint_index(
 )
 
 
-# In[ ]:
+# In[9]:
 
 
 df = get_checkpoint_index()
 df.head()
 
 
-# In[ ]:
+# In[10]:
 
 
 def prep_crop_dataset(
@@ -218,10 +218,16 @@ def prep_crop_dataset(
     return crop_ds
 
 
-# In[ ]:
+# In[11]:
 
 
-for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows():
+from virtual_stain_flow.models.unext import ConvNeXtUNet
+
+
+# In[12]:
+
+
+for i, run_row in unext_run_info_df.reset_index(drop=True,inplace=False).iterrows():
 
     run_id = run_row['run_id']
     run_path = pathlib.Path(run_row["path"])
@@ -230,7 +236,7 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
         model = load_model_weights(
             run_path,
             device=DEVICE,
-            model_handle=UNet,
+            model_handle=ConvNeXtUNet,
             model_config=None,
             compile_model=False
         )
@@ -240,19 +246,15 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
 
     for conds, group in loaddata_df_sub.groupby(
         ['Metadata_Plate', 'row']
-    ):  
-        try:  
-            dataset = prep_crop_dataset(group)
-        except Exception as e:
-            print(f"Error preparing dataset for conditions {conds}: {e}")
-            continue    
+    ): 
 
         try:
             inference_and_checkpoint(
                 model=model,
                 model_metadata=run_row,
                 tasks=group,
-                dataset=dataset,
+                dataset=None,
+                dataset_fn=prep_crop_dataset,
                 output_root=pathlib.Path(INFERENCE_DIR),
                 output_flat=False,
                 device=DEVICE,
@@ -262,7 +264,7 @@ for i, run_row in wgan_run_info_df.reset_index(drop=True,inplace=False).iterrows
             continue        
 
 
-# In[ ]:
+# In[13]:
 
 
 teardown_checkpoint_index()

--- a/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
@@ -1,0 +1,378 @@
+"""
+inference_checkpointing.py
+
+Helper module for checkpointing and resuming inference runs.
+- Initializes a location for writing the index files
+- Keeps tracking of the metadata columns that uniquely identifies models 
+    and inference tasks
+- Checks new inference tasks against existing checkpoint and determine what
+    is truely new and needs to be ran and what should be skipped.
+- Provides helper utility for the inference running helper to update
+    checkpoint files. 
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import pathlib
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class _CheckpointColumnSchema:
+    """
+    Column configuration for checkpoint index files.
+    Defines which columns are used to identify inference tasks and model runs,
+    """
+
+    # Columns that uniquely identify an inference task.
+    # Modify as needed
+    metadata: list[str] = field(default_factory=lambda: [
+        "platemap_file",
+        "Metadata_Plate",
+        "Metadata_Well",
+        "Metadata_Site",
+    ])
+    # Extra bookkeeping columns carried alongside tasks
+    # (not part of the key).
+    # Add/remove as needed
+    metadata_bookkeeping: list[str] = field(default_factory=lambda: [        
+        "time_point",
+        "seeding_density",
+    ])
+    
+    # Model-logging columns that uniquely identify a model run.
+    # Modify as needed, here the run_id is from the mlflow logging records
+    model: list[str] = field(default_factory=lambda: [
+        "run_id"
+    ])
+    
+    # Extra bookkeeping columns from model records.
+    # (not part of the key). 
+    # Add/remove as needed
+    model_bookkeeping: list[str] = field(default_factory=lambda: [
+        "architecture", # model architecture
+        "density", # what density is the model training data
+        "path", # where the logging artifacts are located
+    ])
+
+    # -- derived column lists ------------------------------------------------
+
+    @property
+    def model_prefixed(self) -> list[str]:
+        return [f"Metadata_Model_{c}" for c in self.model]
+
+    @property
+    def model_bookkeeping_prefixed(self) -> list[str]:
+        return [f"Metadata_Model_{c}" for c in self.model_bookkeeping]
+
+    @property
+    def index_columns(self) -> list[str]:
+        """Columns forming the unique (task x model) multi-index key."""
+        return self.metadata + self.model_prefixed
+
+    @property
+    def all_columns(self) -> list[str]:
+        """Every column stored in a checkpoint parquet file."""
+        return (
+            self.metadata
+            + self.model_prefixed
+            + self.metadata_bookkeeping
+            + self.model_bookkeeping_prefixed
+            + ["output_file"]
+        )
+
+    def build_entry(
+        self,
+        task: pd.Series | dict,
+        model_metadata: pd.Series | dict,
+        output_file: pathlib.Path,
+    ) -> dict:
+        """
+        Assemble one checkpoint-index row from task + model metadata.
+        """
+        return {
+            **{c: task[c] for c in self.metadata},
+            **{f"Metadata_Model_{c}": model_metadata[c] for c in self.model},
+            **{c: (task[c] if c in task else None) for c in self.metadata_bookkeeping},
+            **{
+                f"Metadata_Model_{c}": (
+                    model_metadata[c] if c in model_metadata else None
+                )
+                for c in self.model_bookkeeping
+            },
+            "output_file": str(output_file),
+        }
+    
+
+@dataclass
+class _CheckpointSession:
+    """
+    All mutable state for an active checkpointing session.
+    """
+
+    root: pathlib.Path
+    index_root: pathlib.Path
+    index_df: pd.DataFrame
+    multi_index: pd.MultiIndex | None = None
+    new_subdir: pathlib.Path | None = None
+    new_part: int = 0
+
+
+_columns = _CheckpointColumnSchema()
+_session: _CheckpointSession | None = None
+
+# Backward-compatible names imported by sibling modules (model_inference.py).
+# At import time these reference the *same* list objects owned by _columns.
+METADATA_COLUMNS: list[str] = _columns.metadata
+METADATA_COLUMNS_BOOKKEEPING: list[str] = _columns.metadata_bookkeeping
+METADATA_MODEL_COLUMNS: list[str] = _columns.model
+METADATA_MODEL_COLUMNS_BOOKKEEPING: list[str] = _columns.model_bookkeeping
+
+
+# ── Session lifecycle ─────────────────────────────────────────────────────
+
+
+def set_checkpoint_index(
+    checkpoint_root: pathlib.Path,
+    checkpoint_index_path: pathlib.Path | None = None,
+) -> None:
+    """
+    Initialise (or re-initialise) the global checkpoint session.
+
+    Loads existing checkpoint parquet shards from *checkpoint_index_path*
+    and creates a new timestamped subdirectory for this session's writes.
+
+    :param checkpoint_root: Root directory for inference outputs.
+    :param checkpoint_index_path: Directory holding checkpoint parquet files.
+        Defaults to ``checkpoint_root / "checkpoint_index"``.
+    """
+    global _session
+
+    if not checkpoint_root.exists():
+        raise RuntimeError(
+            f"Checkpoint root directory {checkpoint_root} does not exist."
+        )
+
+    if checkpoint_index_path is None:
+        checkpoint_index_path = checkpoint_root / "checkpoint_index"
+        checkpoint_index_path.mkdir(parents=True, exist_ok=True)
+    elif not checkpoint_index_path.exists():
+        raise RuntimeError(
+            f"Checkpoint index path {checkpoint_index_path} does not exist."
+        )
+
+    # Load existing parquet shards
+    collected = list(checkpoint_index_path.rglob("*.parquet"))
+    if collected:
+        index_df = pd.concat(
+            (pd.read_parquet(p) for p in collected),
+            ignore_index=True,
+        )
+    else:
+        index_df = pd.DataFrame(columns=_columns.all_columns)
+
+    if (
+        not all(c in index_df.columns for c in _columns.metadata)
+        and not all(c in index_df.columns for c in _columns.model_prefixed)
+    ):
+        raise ValueError(
+            "Checkpoint index file is missing required metadata columns."
+        )
+
+    multi_index = None
+    if not index_df.empty:
+        multi_index = pd.MultiIndex.from_frame(
+            index_df[_columns.index_columns]
+        )
+
+    new_subdir = checkpoint_index_path / datetime.now().strftime(
+        "%Y-%m-%dT%H-%M-%S-%f"
+    )
+    new_subdir.mkdir(parents=True, exist_ok=True)
+
+    _session = _CheckpointSession(
+        root=checkpoint_root,
+        index_root=checkpoint_index_path,
+        index_df=index_df,
+        multi_index=multi_index,
+        new_subdir=new_subdir,
+    )
+
+
+def teardown_checkpoint_index() -> None:
+    """
+    Tear down the current checkpoint session.
+
+    Iterates over all immediate subdirectories under the checkpoint index
+    root and removes any that are empty (e.g. timestamped run directories
+    that received no checkpoint writes).
+    """
+    global _session
+    if _session is None:
+        return
+
+    for subdir in sorted(_session.index_root.iterdir()):
+        if subdir.is_dir() and not any(subdir.iterdir()):
+            subdir.rmdir()
+
+    _session = None
+
+
+def get_checkpoint_index() -> pd.DataFrame | None:
+    """
+    Get the global checkpoint index DataFrame.
+
+    :return: The checkpoint index DataFrame, or None if it has not been set.
+    """
+    return _session.index_df if _session is not None else None
+
+
+# ── Column configuration ─────────────────────────────────────────────────
+
+
+def set_metadata_columns(columns: list[str]) -> None:
+    """
+    Set the metadata columns to use for checkpointing and resuming inference runs.
+
+    :param columns: List of column names to use as metadata for identifying inference tasks.
+    """
+    global METADATA_COLUMNS
+    _columns.metadata = columns
+    METADATA_COLUMNS = columns
+
+
+def set_metadata_columns_bookkeeping(columns: list[str]) -> None:
+    """
+    Set the bookkeeping metadata columns to include in checkpoint index files.
+
+    :param columns: List of column names to include as bookkeeping metadata.
+    """
+    global METADATA_COLUMNS_BOOKKEEPING
+    _columns.metadata_bookkeeping = columns
+    METADATA_COLUMNS_BOOKKEEPING = columns
+
+
+def set_metadata_model_columns(columns: list[str]) -> None:
+    """
+    Set the metadata model columns to use for checkpointing and resuming inference runs.
+
+    :param columns: List of column names from model logging records to use as metadata for identifying model runs.
+    """
+    global METADATA_MODEL_COLUMNS
+    _columns.model = columns
+    METADATA_MODEL_COLUMNS = columns
+
+
+def set_metadata_model_columns_bookkeeping(columns: list[str]) -> None:
+    """
+    Set the bookkeeping metadata model columns to include in checkpoint index files.
+
+    :param columns: List of column names from model logging records to include as bookkeeping metadata.
+    """
+    global METADATA_MODEL_COLUMNS_BOOKKEEPING
+    _columns.model_bookkeeping = columns
+    METADATA_MODEL_COLUMNS_BOOKKEEPING = columns
+
+
+# ── Task checking & checkpoint updates ────────────────────────────────────
+
+
+def tasks_completed(
+    tasks: pd.DataFrame | Iterable[pd.Series | dict],
+    model: pd.Series | dict,
+) -> pd.DataFrame:
+    """
+    Checks if a batch of inference tasks have already been completed against
+        the global checkpoint index.
+
+    :param tasks: Iterable of Series or dict containing metadata of the
+        inference tasks to check.
+    :param model: Series or dict containing metadata of the model used for the
+        inference tasks.
+    :return: DataFrame containing the subset of tasks that have not been
+        completed according to the checkpoint index.
+    """
+    if _session is None:
+        raise RuntimeError(
+            "Checkpoint index is not set. "
+            "Please call set_checkpoint_index() before checking tasks."
+        )
+
+    if not isinstance(tasks, pd.DataFrame):
+        tasks = pd.DataFrame(tasks)
+
+    if _session.multi_index is None:
+        return tasks
+
+    if not all(c in tasks.columns for c in _columns.metadata):
+        raise ValueError(
+            f"Tasks are missing required metadata columns. "
+            f"Expected at least: {_columns.metadata}"
+        )
+
+    tasks = tasks.dropna(subset=_columns.metadata)
+    tasks[_columns.model_prefixed] = [
+        model[c] for c in _columns.model
+    ]
+
+    tasks_mi = pd.MultiIndex.from_frame(tasks[_columns.index_columns])
+    return tasks.iloc[
+        np.where(~tasks_mi.isin(_session.multi_index))[0]
+    ].copy()
+
+
+def assemble_update_batch(
+    tasks: pd.DataFrame | Iterable[pd.Series | dict],
+    output_files: list[pathlib.Path],
+    model_metadata: pd.Series | dict,
+) -> pd.DataFrame:
+    """
+    Assemble an update DataFrame for a batch of completed inference tasks.
+
+    :param tasks: DataFrame or iterable of Series/dict with task metadata.
+    :param output_files: Output file paths for the completed tasks.
+    :param model_metadata: Metadata of the model used for inference.
+    :return: DataFrame with one row per checkpoint entry.
+    """
+    if isinstance(tasks, pd.DataFrame):
+        task_list = [row for _, row in tasks.iterrows()]
+    else:
+        task_list = list(tasks)
+
+    if len(task_list) != len(output_files):
+        raise ValueError(
+            f"Number of tasks and output files must match. "
+            f"Got {len(task_list)} tasks and {len(output_files)} output files."
+        )
+
+    return pd.DataFrame([
+        _columns.build_entry(task, model_metadata, output_files[i])
+        for i, task in enumerate(task_list)
+    ])
+
+
+def update_checkpoint_batch(
+    tasks: pd.DataFrame | Iterable[pd.Series | dict],
+    output_files: list[pathlib.Path],
+    model_metadata: pd.Series | dict,
+) -> None:
+    """
+    Update the checkpoint index with a batch of completed inference tasks.
+
+    :param tasks: Iterable of Series or dict containing metadata of the completed inference tasks.
+    :param output_files: List of output file paths corresponding to the completed inference tasks.
+    :param model_metadata: Series or dict containing metadata of the model used for the inference tasks.
+    """
+    if _session is None:
+        raise RuntimeError(
+            "Checkpoint index is not set. "
+            "Please call set_checkpoint_index() before updating."
+        )
+
+    _session.index_df = assemble_update_batch(tasks, output_files, model_metadata)
+    part_path = _session.new_subdir / f"part_{_session.new_part}.parquet"
+    _session.index_df.to_parquet(part_path, index=False)
+    _session.new_part += 1

--- a/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
@@ -368,8 +368,11 @@ def assemble_update_batch(
     """
     if isinstance(tasks, pd.DataFrame):
         task_list = tasks.to_dict(orient="records")
+    elif isinstance(tasks, list):
+        task_list = tasks
     else:
-        task_list = list(tasks)
+        raise TypeError("tasks must be a DataFrame or a list of dicts/Series")
+
 
     if len(task_list) != len(output_files):
         raise ValueError(

--- a/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
@@ -92,25 +92,52 @@ class _CheckpointColumnSchema:
     ) -> dict:
         """
         Assemble one checkpoint-index row from task + model metadata.
+        This can be used by the parquet update helper to assemble the
+            updated checkpoint rows after an inference batch is compelted.
         """
         return {
+            # Task metadata columns
             **{c: task[c] for c in self.metadata},
+            # Model metadata columns with prepended prefix to model data
             **{f"Metadata_Model_{c}": model_metadata[c] for c in self.model},
+            # Bookkeeping metadata columns (not part of the key), included if present in task/model metadata
             **{c: (task[c] if c in task else None) for c in self.metadata_bookkeeping},
+            # Bookkeeping model metadata columns with prepended prefix, included if present in model metadata
             **{
                 f"Metadata_Model_{c}": (
                     model_metadata[c] if c in model_metadata else None
                 )
                 for c in self.model_bookkeeping
             },
+            # Output file path for the inference result (tif files written)
             "output_file": str(output_file),
         }
     
+    def set_metadata(self, metadata_cols: list[str]) -> None:
+        self.metadata = metadata_cols
+
+    def set_metadata_bookkeeping(self, bookkeeping_cols: list[str]) -> None:
+        self.metadata_bookkeeping = bookkeeping_cols
+
+    def set_model_metadata(self, model_cols: list[str]) -> None:
+        self.model = model_cols
+
+    def set_model_bookkeeping(self, model_bookkeeping_cols: list[str]) -> None:
+        self.model_bookkeeping = model_bookkeeping_cols    
+
 
 @dataclass
 class _CheckpointSession:
     """
-    All mutable state for an active checkpointing session.
+    Dataclass serving as a state object for an active checkpointing session.
+    Initialized automatically by set_checkpoint_index() and kept as
+        a global variable for the session, which is accessed by exposed helpers
+        including tasks_completed(), assemble_update_batch(), and update_checkpoint_batch().  
+    The only mutable component of this state object is the counter 
+        tracking the parquet file parts written during the session. 
+    Every thing else (pathing, index DataFrame, and MultiIndex) are 
+        immutable session metadata that is needed by the inference runner
+        and hence bundled. 
     """
 
     root: pathlib.Path
@@ -165,6 +192,7 @@ def set_checkpoint_index(
         )
 
     # Load existing parquet shards
+    # rglob will be needed due to the nested timestamped subdirectory structure
     collected = list(checkpoint_index_path.rglob("*.parquet"))
     if collected:
         index_df = pd.concat(
@@ -172,6 +200,7 @@ def set_checkpoint_index(
             ignore_index=True,
         )
     else:
+        # if no existing checkpoint, initialize empty index with the right columns
         index_df = pd.DataFrame(columns=_columns.all_columns)
 
     if (

--- a/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/inference_checkpointing.py
@@ -14,7 +14,7 @@ Helper module for checkpointing and resuming inference runs.
 from dataclasses import dataclass, field
 from datetime import datetime
 import pathlib
-from typing import Iterable
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -310,14 +310,14 @@ def set_metadata_model_columns_bookkeeping(columns: list[str]) -> None:
 
 
 def tasks_completed(
-    tasks: pd.DataFrame | Iterable[pd.Series | dict],
+    tasks: pd.DataFrame | List[pd.Series | dict],
     model: pd.Series | dict,
 ) -> pd.DataFrame:
     """
     Checks if a batch of inference tasks have already been completed against
         the global checkpoint index.
 
-    :param tasks: Iterable of Series or dict containing metadata of the
+    :param tasks: List of Series or dict containing metadata of the
         inference tasks to check.
     :param model: Series or dict containing metadata of the model used for the
         inference tasks.
@@ -354,20 +354,20 @@ def tasks_completed(
 
 
 def assemble_update_batch(
-    tasks: pd.DataFrame | Iterable[pd.Series | dict],
+    tasks: pd.DataFrame | List[pd.Series | dict],
     output_files: list[pathlib.Path],
     model_metadata: pd.Series | dict,
 ) -> pd.DataFrame:
     """
     Assemble an update DataFrame for a batch of completed inference tasks.
 
-    :param tasks: DataFrame or iterable of Series/dict with task metadata.
+    :param tasks: DataFrame or List of Series/dict with task metadata.
     :param output_files: Output file paths for the completed tasks.
     :param model_metadata: Metadata of the model used for inference.
     :return: DataFrame with one row per checkpoint entry.
     """
     if isinstance(tasks, pd.DataFrame):
-        task_list = [row for _, row in tasks.iterrows()]
+        task_list = tasks.to_dict(orient="records")
     else:
         task_list = list(tasks)
 
@@ -384,14 +384,14 @@ def assemble_update_batch(
 
 
 def update_checkpoint_batch(
-    tasks: pd.DataFrame | Iterable[pd.Series | dict],
+    tasks: pd.DataFrame | List[pd.Series | dict],
     output_files: list[pathlib.Path],
     model_metadata: pd.Series | dict,
 ) -> None:
     """
     Update the checkpoint index with a batch of completed inference tasks.
 
-    :param tasks: Iterable of Series or dict containing metadata of the completed inference tasks.
+    :param tasks: List of Series or dict containing metadata of the completed inference tasks.
     :param output_files: List of output file paths corresponding to the completed inference tasks.
     :param model_metadata: Series or dict containing metadata of the model used for the inference tasks.
     """

--- a/4.virtual_staining_analysis/src/vs_eval_utils/model_inference.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/model_inference.py
@@ -1,0 +1,163 @@
+"""
+model_inference.py
+
+This module contains utilities for running inference on a specified image dataset
+given a loaded model and its metadata, and write checkpoint files for indexing
+what has been inferenced and what still needs to be done.
+"""
+
+import pathlib
+
+import numpy as np
+import pandas as pd
+from tqdm.auto import tqdm
+import torch
+import tifffile as tiff
+
+from .inference_checkpointing import (
+    METADATA_COLUMNS,
+    METADATA_MODEL_COLUMNS,
+    tasks_completed,
+    update_checkpoint_batch,
+)
+
+
+def construct_output_path(
+    metadata_values: list[str],
+    model_metadata_values: list[str],
+    patch_i: int,
+    output_root: pathlib.Path,
+    flat: bool = False
+) -> pathlib.Path:    
+    """
+    Construct output path for inference results based on metadata values.
+
+    :param metadata_values: List of metadata values for the inference task.
+    :param model_metadata_values: List of model metadata values for the inference task.
+    :param output_root: Root directory to save inference outputs.
+    :param flat: Whether to use a flat directory structure (default: False).
+    :return: Path to save inference results for the given task.
+    """
+
+    if flat:
+        # For flat structure, concatenate all metadata values into a single filename
+        filename = "_".join(f"{value}" for value in metadata_values + model_metadata_values)
+        filename = filename.replace("/", "_")  # replace any slashes in metadata values to avoid path issues
+        return output_root / f"{filename}_{patch_i}.tiff"
+    
+    # For hierarchical structure, create subdirectories based on metadata values
+    subdir = output_root
+    for val in metadata_values:
+        subdir /= str(val)
+    
+    model_subdir = subdir
+    for val in model_metadata_values:
+        model_subdir /= str(val)
+
+    model_subdir.mkdir(parents=True, exist_ok=True)
+    
+    return model_subdir / f"{patch_i}.tiff"
+
+
+def inference_and_checkpoint(
+    model: torch.nn.Module,
+    model_metadata: pd.Series | dict,
+    tasks: pd.DataFrame,
+    dataset: torch.utils.data.Dataset,
+    output_root: pathlib.Path,
+    output_flat: bool = True,
+    device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+) -> None:
+    """
+    Run inference on the given dataloader using the provided model, and manage checkpointing of completed tasks.
+
+    :param model: The PyTorch model to use for inference.
+    :param model_metadata: Metadata of the model being used for inference.
+    :param tasks: DataFrame containing metadata of tasks to run inference on.
+    :param dataset: Dataset to run inference on, which should be compatible with the tasks DataFrame.
+    :param output_root: Root directory to save inference outputs and checkpoint files.
+    """
+
+    # Use checkpoining module to determine if any tasks have already been
+    # completed for this model and set of tasks, to avoid redundant inference runs.
+    tasks_todo: pd.DataFrame = tasks_completed(
+        tasks=tasks,
+        model=model_metadata
+    )
+    tasks_todo.reset_index(drop=True, inplace=True)
+
+    if tasks_todo.empty:
+        print("All tasks have already been completed for this model. No inference to run.")
+        return 
+    
+    try:
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=48,
+            num_workers=4,
+            pin_memory=False,
+            shuffle=False,
+        )
+    except Exception as e:
+        raise RuntimeError(f"Error creating dataloader for inference: {e}")
+    
+    model = model.to(device)
+
+    inference_cache: list[torch.Tensor] = []
+    pbar = tqdm(dataloader, desc="Running inference", total=len(dataloader))
+    with torch.inference_mode():
+        for batch in pbar:
+            
+            inputs, _ = batch
+            inputs = inputs.to(device)
+            outputs = model(inputs)
+            bs = outputs.shape[0]
+
+            # temporarily store all outputs in gpu memory
+            inference_cache.append(outputs)
+
+    # once the inference completes the progress bar disappears too.
+    pbar.close() 
+
+    inference: np.ndarray = torch.cat(inference_cache, dim=0).cpu().numpy().astype(np.float32)
+    # refuse to write outputs and update checkpoint if number of outputs does
+    # not match number of tasks, to avoid silent data corruption
+    if inference.shape[0] != len(dataset._metadata):
+        raise RuntimeError(
+            f"Number of inference outputs ({inference.shape[0]}) "
+            f"does not match number of tasks ({len(dataset._metadata)})."
+        )    
+
+    update_paths: list[pathlib.Path] = []
+    for idx, task in dataset._metadata.iterrows():
+
+        metadata_values: list[str] = [
+            task[col] for col in METADATA_COLUMNS
+        ]
+        
+        model_metadata_values: list[str] = [
+            model_metadata[col] for col in METADATA_MODEL_COLUMNS
+        ]
+
+        output_path = construct_output_path(
+            metadata_values=metadata_values,
+            model_metadata_values=model_metadata_values,
+            patch_i=idx,
+            output_root=output_root,
+            flat=output_flat,
+        )
+
+        try:
+            tiff.imwrite(output_path, inference[idx, ...])
+            update_paths.append(output_path)
+        except Exception:
+            # If writing the output fails, we do not want to mark the task as completed in the checkpoint index, to avoid data corruption.
+            err_file = output_path.with_suffix(".err")
+            err_file.touch(exist_ok=True)
+            update_paths.append(err_file)
+
+    update_checkpoint_batch(
+        tasks=dataset._metadata,
+        output_files=update_paths,
+        model_metadata=model_metadata,
+    )

--- a/4.virtual_staining_analysis/src/vs_eval_utils/model_inference.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/model_inference.py
@@ -7,6 +7,7 @@ what has been inferenced and what still needs to be done.
 """
 
 import pathlib
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -63,8 +64,9 @@ def inference_and_checkpoint(
     model: torch.nn.Module,
     model_metadata: pd.Series | dict,
     tasks: pd.DataFrame,
-    dataset: torch.utils.data.Dataset,
     output_root: pathlib.Path,
+    dataset: Optional[torch.utils.data.Dataset] = None,
+    dataset_fn: Optional[callable] = None,
     output_flat: bool = True,
     device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu"),
 ) -> None:
@@ -75,6 +77,7 @@ def inference_and_checkpoint(
     :param model_metadata: Metadata of the model being used for inference.
     :param tasks: DataFrame containing metadata of tasks to run inference on.
     :param dataset: Dataset to run inference on, which should be compatible with the tasks DataFrame.
+    :param dataset_fn: Optional function to create a dataset if dataset is None.
     :param output_root: Root directory to save inference outputs and checkpoint files.
     """
 
@@ -90,6 +93,15 @@ def inference_and_checkpoint(
         print("All tasks have already been completed for this model. No inference to run.")
         return 
     
+    # lazy dataset construction
+    if dataset is None:
+        if dataset_fn is None:
+            raise ValueError("Either a dataset or a dataset_fn must be provided.")
+        try:
+            dataset = dataset_fn(tasks_todo)
+        except Exception:
+            raise ValueError("Failed to create dataset using dataset_fn.")
+
     try:
         dataloader = torch.utils.data.DataLoader(
             dataset,

--- a/4.virtual_staining_analysis/src/vs_eval_utils/model_loader.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/model_loader.py
@@ -1,0 +1,121 @@
+"""
+model_loader.py
+
+Simple utility function for loading model weights from training runs.
+Coupled to the https://github.com/WayScience/virtual_stain_flow 
+    virtual_stain_flow package implementation. 
+"""
+
+import json
+import pathlib
+
+import torch
+
+
+def load_model_weights(
+    run_path: pathlib.Path,
+    device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+    model_handle: callable = None,
+    model_config: dict | None = None,
+    compile_model: bool = False,
+) -> torch.nn.Module | None:
+    """
+    Load model weights from a training run directory.
+
+    :param run_path: Path to the training run directory containing logged artifacts.
+    :param device: Device to load the model onto (default: CUDA if available, else CPU).
+    :param model_handle: Optional callable that returns an uninitialized model instance.
+    :param model_config: Optional dictionary of model initialization parameters.
+        If not provided, the function will attempt to load a model config from 
+        the run artifacts, which may not be available for older logging versions.
+    : param compile_model: Whether to compile the model after loading weights (default: False).
+    :return: Loaded model with weights, or None if loading failed.
+    """
+
+    possible_weight_file_patterns = [
+        "generator",
+        "model",
+        "best",
+    ]
+
+    candidate_weight_files = list(
+        (run_path / "artifacts").rglob("*.pth")
+    )
+    matched_files = []
+    for pattern in possible_weight_file_patterns:
+        matched_files = [file for file in candidate_weight_files if pattern in file.name]
+        if matched_files:
+            break
+
+    if not matched_files:        
+        raise RuntimeError(
+            f"No model weight files found in expected locations for run {run_path}."
+        )
+
+    # select weights to use
+    chosen_weights = matched_files
+    # usually best model weights are updated over training and always saved as a
+    # specific "best" file
+    best_weights = [p for p in chosen_weights if "best" in p.name]
+    if best_weights:
+        chosen_weight = best_weights[0]
+    else:
+        # Find the latest weights
+        # Assume filenames end with an epoch/step integer
+        # Assume model doesn't overtrain with the configured max epochs
+        try:
+            chosen_weight = sorted(
+                chosen_weights,
+                key=lambda p: int(p.stem.split("_")[-1]),
+            )[-1]
+        except ValueError: # allow for non-integer suffixes, fallback to last
+            chosen_weight = chosen_weights[-1]
+            # all other errors let it fails
+
+    if not chosen_weight.exists():
+        raise RuntimeError(
+            f"Selected model weight file {chosen_weight} does not exist."
+        )    
+
+    if not model_config:
+        model_config_path = run_path / "artifacts" / "configs" / "model_config.json"
+        if not model_config_path.exists():
+            raise RuntimeError(
+                "No model config found at expected location "
+                f"{model_config_path} for run {run_path}."
+                "Please manually provide model_config or ensure logging version saves it."
+            )
+        try:
+            model_config = json.loads(model_config_path.read_text())
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load model config from {model_config_path}: {e}"
+            )
+    try:
+        model = model_handle(
+            **model_config['init']
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to initialize model with config {model_config}: {e}"
+        )
+
+    if not model or not isinstance(model, torch.nn.Module):
+        raise RuntimeError(
+            f"Model handle did not return a valid torch.nn.Module instance: {model}"
+        )
+    
+    try:
+        model.to(device)
+        model.eval()
+        if compile_model:
+            model = torch.compile(model)
+        state_dict = torch.load(chosen_weight, map_location=device)
+        # print weight loading to see if <all keys matched successfully> message is returned
+        print(model.load_state_dict(state_dict))
+    except Exception as e:
+        raise RuntimeError(
+            f"Failed to load model weights from {chosen_weight}: {e}"
+        )
+
+    return model

--- a/4.virtual_staining_analysis/src/vs_eval_utils/model_loader.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/model_loader.py
@@ -77,20 +77,30 @@ def load_model_weights(
             f"Selected model weight file {chosen_weight} does not exist."
         )    
 
-    if not model_config:
-        model_config_path = run_path / "artifacts" / "configs" / "model_config.json"
-        if not model_config_path.exists():
-            raise RuntimeError(
-                "No model config found at expected location "
-                f"{model_config_path} for run {run_path}."
-                "Please manually provide model_config or ensure logging version saves it."
-            )
+    logged_model_config = None
+
+    # prefer logged model config if available since it is directly tied to the weights
+    model_config_path = run_path / "artifacts" / "configs" / "model_config.json"
+    if model_config_path.exists():
         try:
-            model_config = json.loads(model_config_path.read_text())
+            logged_model_config = json.loads(model_config_path.read_text())
         except Exception as e:
+            logged_model_config = None
             raise RuntimeError(
                 f"Failed to load model config from {model_config_path}: {e}"
+            )    
+    
+    if logged_model_config:
+        model_config = logged_model_config
+    else:
+        # if no logged config, rely on provided config defaults which 
+        # now will be required
+        if not model_config:
+            raise RuntimeError(
+                f"No model config provided or found for run {run_path}. "
+                "Cannot initialize model without config."
             )
+    
     try:
         model = model_handle(
             **model_config['init']

--- a/4.virtual_staining_analysis/src/vs_eval_utils/nb_utils.py
+++ b/4.virtual_staining_analysis/src/vs_eval_utils/nb_utils.py
@@ -1,0 +1,37 @@
+"""
+Helper functions for virtual staining evaluation notebooks.
+"""
+
+import pathlib
+import inspect
+
+def find_git_root(start_path: pathlib.Path | None = None) -> pathlib.Path:
+    """
+    Recursively search upward for a Git repository root
+    (directory containing .git).
+
+    Works for both .py and .ipynb contexts.
+    """
+    if start_path is None:
+        # Case 1: Called from a normal .py file
+        if "__file__" in globals():
+            start_path = pathlib.Path(__file__).resolve()
+        else:
+            # Case 2: Notebook / interactive
+            # Try to infer from call stack
+            frame = inspect.stack()[1]
+            module = inspect.getmodule(frame[0])
+            if module and hasattr(module, "__file__"):
+                start_path = pathlib.Path(module.__file__).resolve()
+            else:
+                # Fallback: current working directory
+                start_path = pathlib.Path.cwd()
+
+    start_path = start_path if start_path.is_dir() else start_path.parent
+
+    for parent in [start_path, *start_path.parents]:
+        git_path = parent / ".git"
+        if git_path.exists():
+            return parent
+
+    raise RuntimeError("No Git repository found.")


### PR DESCRIPTION
This pull request introduces a checkpointed batch inference workflow for virtual staining models (wGAN architecture for now, UNet and UNeXt later) on pediatric cancer atlas imaging data. Note that the added analysis folder says 4.xxx, there will be a 3.train_model to house the train model scripts to be added in the future. 

**Batch inference workflow and script:**
- Added a new script `4.1b.run_model_inferences_wgan.py` that orchestrates batch inference for wGAN models, including loading data, filtering, checkpointing, running inference on grouped data, and writing outputs. The script ensures only new or incomplete tasks are processed and supports resuming interrupted runs.
- A script 4.1a for unet and a script 4.1c for unexts will be added shortly

**Checkpointing infrastructure:**
- `src/vs_eval_utils/inference_checkpointing.py`: tracks completed inference tasks, supports resuming, and prevents redundant computation by maintaining a multi-indexed checkpoint DataFrame.

**Inference utilities:**
- `src/vs_eval_utils/model_inference.py`: utilities for running inference on datasets with a specified model, constructing output paths, writing results, and updating checkpoint files. It integrates with the checkpointing module to ensure only pending tasks are run and results are consistently tracked.